### PR TITLE
Fix formatting in 2.0 announcement messages

### DIFF
--- a/resources/views/appeals/appeallist.blade.php
+++ b/resources/views/appeals/appeallist.blade.php
@@ -6,7 +6,7 @@
 
 	Please note:
 	<ul>
-	<li>In doing this, please understand that there will be bugs and issues. We will try our best to keep up with those issues. You can get assistance at [[WT:UTRS|the UTRS talkpage]] (preferably) or by placing {!! "{{tl|UTRS help me}}" !!} on your talkpage.</li>
+	<li>In doing this, please understand that there will be bugs and issues. We will try our best to keep up with those issues. You can get assistance at [[WT:UTRS|the UTRS talkpage]] (preferably) or by placing <a href="https://en.wikipedia.org/wiki/Template:UTRS_help_me">@{{UTRS help me}}</a> on your talkpage.</li>
 	<li>New features are not being considered at this time. Though your idea may have already been thought of and be in development.</li>
 	<li>Administrators will need to create a new login to use UTRS 2.0. The only thing that needs to match is your Wikipedia username. You should receive a confirmation email to verify your account within 5 minutes. At this time, there is no plans for reintegrating OAuth for login (for multiple reasons).</li>
 	<li>Temporary tool administrator status can be requested on [[WT:UTRS]], and will be granted liberally at this time to help create templates from the [https://utrs.wmflabs.org/tempMgmt.php old version]. All bans, user management, and other tool administration functions are only available via the database or automated scripts already running on the server at this time.</li>

--- a/resources/views/appeals/appeallist.blade.php
+++ b/resources/views/appeals/appeallist.blade.php
@@ -6,10 +6,10 @@
 
 	Please note:
 	<ul>
-	<li>In doing this, please understand that there will be bugs and issues. We will try our best to keep up with those issues. You can get assistance at [[WT:UTRS|the UTRS talkpage]] (preferably) or by placing <a href="https://en.wikipedia.org/wiki/Template:UTRS_help_me">@{{UTRS help me}}</a> on your talkpage.</li>
+	<li>In doing this, please understand that there will be bugs and issues. We will try our best to keep up with those issues. You can get assistance at <a href="https://en.wikipedia.org/wiki/Wikipedia_talk:Unblock_Ticket_Request_System">the UTRS talkpage</a> (preferably) or by placing <a href="https://en.wikipedia.org/wiki/Template:UTRS_help_me">@{{UTRS help me}}</a> on your talkpage.</li>
 	<li>New features are not being considered at this time. Though your idea may have already been thought of and be in development.</li>
 	<li>Administrators will need to create a new login to use UTRS 2.0. The only thing that needs to match is your Wikipedia username. You should receive a confirmation email to verify your account within 5 minutes. At this time, there is no plans for reintegrating OAuth for login (for multiple reasons).</li>
-	<li>Temporary tool administrator status can be requested on [[WT:UTRS]], and will be granted liberally at this time to help create templates from the [https://utrs.wmflabs.org/tempMgmt.php old version]. All bans, user management, and other tool administration functions are only available via the database or automated scripts already running on the server at this time.</li>
+	<li>Temporary tool administrator status can be requested on <a href="https://en.wikipedia.org/wiki/Wikipedia_talk:Unblock_Ticket_Request_System">WT:UTRS</a>, and will be granted liberally at this time to help create templates from the <a href="https://utrs.wmflabs.org/tempMgmt.php">old version</a>. All bans, user management, and other tool administration functions are only available via the database or automated scripts already running on the server at this time.</li>
 	<li>More information will be available in the days to come about the features of UTRS.</li>
 	</ul>
 

--- a/resources/views/appeals/publicappeal.blade.php
+++ b/resources/views/appeals/publicappeal.blade.php
@@ -5,7 +5,7 @@
 <div class="alert alert-danger" role="alert">
     <b>IMPORTANT MESSAGE</b><br />
     UTRS is in the process of moving over to UTRS 2.0 of the software. We needed to do this because several users were unable to file proper appeals due to IPv6 IP addresses not being accepted by our severs. Therefore, we made the decision to move over to a rudimentary beta software instead to allow everyone to appeal properly.<br /><br />
-    In doing this, please understand that there will be bugs and issues. We will try our best to keep up with those issues. You can get assistance at <a href="https://en.wikipedia.org/wiki/Wikipedia_talk:Unblock_Ticket_Request_System">the UTRS talkpage</a> or by placing {!! "{{tl|UTRS help me}}" !!} on your talkpage.<br /><br />
+    In doing this, please understand that there will be bugs and issues. We will try our best to keep up with those issues. You can get assistance at <a href="https://en.wikipedia.org/wiki/Wikipedia_talk:Unblock_Ticket_Request_System">the UTRS talkpage</a> or by placing <a href="https://en.wikipedia.org/wiki/Template:UTRS_help_me">@{{UTRS help me}}</a> on your talkpage.<br /><br />
     <b>Note: During this time, no emails will be sent out for appeals except for blocks that are not found for accounts. That means you need to keep your appeal secret key on hand at all times (DON'T SHARE IT) and check back regularly.</b><br /><br />
     We thank you for your patience.<br />
     UTRS Development Team

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -4,7 +4,7 @@
 <div class="alert alert-danger" role="alert">
     <b>IMPORTANT MESSAGE</b><br />
     UTRS is in the process of moving over to UTRS 2.0 of the software. We needed to do this because several users were unable to file proper appeals due to IPv6 IP addresses not being accepted by our severs. Therefore, we made the decision to move over to a rudimentary beta software instead to allow everyone to appeal properly.<br /><br />
-    In doing this, please understand that there will be bugs and issues. We will try our best to keep up with those issues. You can get assistance at <a href="https://en.wikipedia.org/wiki/Wikipedia_talk:Unblock_Ticket_Request_System">the UTRS talkpage</a> or by placing {!! "{{tl|UTRS help me}}" !!} on your talkpage.<br /><br />
+    In doing this, please understand that there will be bugs and issues. We will try our best to keep up with those issues. You can get assistance at <a href="https://en.wikipedia.org/wiki/Wikipedia_talk:Unblock_Ticket_Request_System">the UTRS talkpage</a> or by placing <a href="https://en.wikipedia.org/wiki/Template:UTRS_help_me">@{{UTRS help me}}</a> on your talkpage.<br /><br />
     <b>Note: During this time, no emails will be sent out for appeals except for blocks that are not found for accounts. That means you need to keep your appeal secret key on hand at all times (DON'T SHARE IT) and check back regularly.</b><br /><br />
     We thank you for your patience.<br />
     UTRS Development Team


### PR DESCRIPTION
Somehow this didn't render anything, I fixed it by using "@{{ some text }}" which produces "{{ some text }}" in the output and added a link to the template documentation