### PR TITLE
Reduce database query amount in Permission logic

### DIFF
--- a/app/Permission.php
+++ b/app/Permission.php
@@ -55,10 +55,14 @@ class Permission extends Model
     		abort(403,'No logged in user');
     	}
         if ($wiki=="*") {
-            $specific = Permission::where('userid','=',$id)->where('wiki','=','*')->first();
+            $specific = Permission::where('userid','=',$id)
+                ->where('wiki','=','*')->first();
         }
     	else {
-            $specific = Permission::where('userid','=',$id)->where('wiki','rlike','\\*|'.$wiki)->first();
+            $specific = Permission::where('userid','=',$id)
+                ->where('wiki', $wiki)
+                ->orWhere('wiki', '*')
+                ->first();
         }
     	if ($level == "OVERSIGHT") {
     		if ($specific['oversight']==1) {return True;}


### PR DESCRIPTION
This PR makes checking for permissions more efficient:

* Every call to `Permission::checkSecurity` did an SQL query so I made it only do 2 queries (one for local and one for global permissions).
* It uses syntax like `WHERE wiki="enwiki" OR WIKI="*"` instead of `WHERE wiki RLIKE "enwiki|*"` as regexes are more expensive
  * I'm not sure why it even does that as only the first result will be examined but I didn't want to touch the logic itself as I didn't want to break something
* Using `->first()` instead of `->get()->first()` adds `LIMIT 1` to the DB side so the database stops searching when it finds the first result instead of searching the full table