### PR TITLE
Fix block detail job for blocks without a hidden ip and a wrong username

### DIFF
--- a/app/Jobs/GetBlockDetailsJob.php
+++ b/app/Jobs/GetBlockDetailsJob.php
@@ -62,7 +62,7 @@ class GetBlockDetailsJob implements ShouldQueue
         } else {
             $blockData = MwApiExtras::getBlockInfo($this->appeal->wiki, $this->appeal->appealfor);
 
-            if (!$blockData) {
+            if (!$blockData && !empty($this->appeal->hiddenip)) {
                 $blockData = MwApiExtras::getBlockInfo($this->appeal->wiki, $this->appeal->hiddenip);
             }
 


### PR DESCRIPTION
I found a bug where GetBlockDetailsJob might have found block details for a wrong person when they typed their username/IP wrong. This slipped thru when testing for #33.