### PR TITLE
Fix some users not being able to view some appeals

### DIFF
--- a/app/Http/Controllers/AppealController.php
+++ b/app/Http/Controllers/AppealController.php
@@ -180,14 +180,14 @@ class AppealController extends Controller
 
     public function appeallist()
     {
-        $isTooladmin = false;
-        $isDeveloper = Permission::checkSecurity(Auth::id(), "DEVELOPER", "*");
-      
         abort_unless(Auth::check(), 403, 'No logged in user');
         /** @var User $user */
         $user = Auth::user();
 
         $user->checkRead();
+
+        $isTooladmin = false;
+        $isDeveloper = Permission::checkSecurity(Auth::id(), "DEVELOPER", "*");
 
         if ($user->wikis === '*' || $isDeveloper) {
             $wikis = collect(MwApiUrls::getSupportedWikis())

--- a/app/Http/Controllers/AppealController.php
+++ b/app/Http/Controllers/AppealController.php
@@ -205,11 +205,12 @@ class AppealController extends Controller
             }
         }
 
-        $regularnoview = [Appeal::STATUS_ACCEPT, Appeal::STATUS_DECLINE, Appeal::STATUS_EXPIRE, Appeal::STATUS_VERIFY, Appeal::STATUS_NOTFOUND, Appeal::STATUS_INVALID];
-        $devnoview = [Appeal::STATUS_ACCEPT, Appeal::STATUS_DECLINE, Appeal::STATUS_EXPIRE, Appeal::STATUS_INVALID];
+        $hiddenStatuses = $isDeveloper
+            ? [Appeal::STATUS_ACCEPT, Appeal::STATUS_DECLINE, Appeal::STATUS_EXPIRE, Appeal::STATUS_INVALID]
+            : [Appeal::STATUS_ACCEPT, Appeal::STATUS_DECLINE, Appeal::STATUS_EXPIRE, Appeal::STATUS_VERIFY, Appeal::STATUS_NOTFOUND, Appeal::STATUS_INVALID];
 
         $appeals = Appeal::whereIn('wiki', $wikis)
-            ->whereIn('status', $isDeveloper ? $devnoview : $regularnoview)
+            ->whereNotIn('status', $hiddenStatuses)
             ->get();
 
         return view('appeals.appeallist', ['appeals' => $appeals, 'tooladmin' => $isTooladmin]);


### PR DESCRIPTION
This fixes a bug where users would only see appeals for the last value of `users.wikis`, not for all of them.

I think that this should fix #163, but that's only an educated guess.