### PR TITLE
GitHub actions improvements, documentate frontend assets to test caching

### DIFF
--- a/.github/workflows/laravel-tests.yml
+++ b/.github/workflows/laravel-tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     services:
       mysql:
-        image: mysql:8
+        image: mariadb:10.5
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: false
           MYSQL_ROOT_PASSWORD: password
@@ -21,6 +21,26 @@ jobs:
       - uses: actions/checkout@v1
       - name: Copy env file
         run: cp .env.ci .env
+      - name: Cache Composer dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-composer-dependencies
+        with:
+          path: ~/.composer/cache/files
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+      - name: Cache NPM dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-dependencies
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
       - name: Install Composer dependencies
         run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
       - name: Install NPM dependencies
@@ -29,8 +49,6 @@ jobs:
         run: php artisan key:generate
       - name: Clear config cache
         run: php${{ matrix.php }} artisan config:clear
-      - name: Verify MySQL connection from host
-        run: mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports['3306'] }} -uroot -ppassword -e "SHOW DATABASES"
       - name: Run migrations
         run: php${{ matrix.php }} artisan migrate -v --force --seed
         env:
@@ -41,11 +59,8 @@ jobs:
         run: vendor/bin/phpunit
         env:
           DB_PORT: ${{ job.services.mysql.ports['3306'] }}
-      - name: Upgrade Chrome Driver
-        run: php artisan dusk:chrome-driver 83
-        # if this breaks, look up from https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu2004-README.md or updated version
-      - name: Start Chrome Driver
-        run: ./vendor/laravel/dusk/bin/chromedriver-linux &
+      - name: Start chromedriver
+        run: chromedriver &
       - name: Start Laravel Server
         run: php artisan serve &
         env:
@@ -56,7 +71,7 @@ jobs:
           DB_PORT: ${{ job.services.mysql.ports['3306'] }}
       - uses: actions/upload-artifact@v2
         name: Save Dusk screenshots
-        if: always()
+        if: failure()
         with:
           name: dusk-screenshots
           path: tests/Browser/screenshots/*.png

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,20 @@
 
 The /public subdirectory is the webroot. You can either use `php artisan serve` to run a standalone webserver, or point your webserver of choice at /public
 
+## Building frontend assets
+
+The frontend is built using Bootstrap 4. It uses `purgecss` to remove unused classes to reduce bundle size. This can create complications for development thru.
+
+First, install NPM dependencies using `npm install`. Then, you can use Laravel Mix (webpack wrapper) to build assets:
+
+* Use `npm run watch` to start Webpack mix in development watch mode. That mode does not use PurgeCSS and it re-builds
+  all assets when it detects a change. This is most useful when working with JavaScript or when modifying the SCSS files.
+* Use `npm run dev` to do one build in the development mode. This mode does not use PurgeCSS. This is most useful when
+  you are working on the frontend, as you have access to all classes Bootstrap has to offer.
+* Use `npm run prod` to do a production build. This build uses PurgeCSS and URL versioning. Due to legacy reasons a
+  production build should be commited to the repository for pull requests. This may change soon, see issue
+  [#240](https://github.com/UTRS2/utrs/issues/240).
+
 ## Setting up MediaWiki integration (for testing)
 
 ### API calls


### PR DESCRIPTION
The following changes seem to reduce time taken to run tests from about 6 minutes to 3,5 minutes:
* Run with MariaDB instead of MySQL
* Cache dependencies so downloading them is faster
* Use alread installed chromedriver instead of downloading our own
* Only save dusk screenshots when tests failed
* Add documentation for building frontend assets to test caching system