### PR TITLE
Store users CentralAuth IDs to allow detecting renamed users

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -23,12 +23,12 @@ class UserController extends Controller
         $this->authorize('viewAny', User::class);
         $allusers = User::all();
 
-        $tableheaders = ['ID', 'Username', 'Last Permissions Check'];
+        $tableheaders = ['ID', 'Username', 'CentralAuth ID', 'Last Permissions Check'];
         $rowcontents = [];
 
         foreach ($allusers as $user) {
             $idbutton = '<a href="' . route('admin.users.view', $user) . '"><button type="button" class="btn btn-primary">' . $user->id . '</button></a>';
-            $rowcontents[$user->id] = [$idbutton, htmlspecialchars($user->username), $user->last_permission_check_at];
+            $rowcontents[$user->id] = [$idbutton, htmlspecialchars($user->username), $user->mediawiki_id ?? '(not known)', $user->last_permission_check_at];
         }
 
         return view('admin.tables', ['title' => 'All Users', 'tableheaders' => $tableheaders, 'rowcontents' => $rowcontents]);

--- a/app/Http/Controllers/Auth/OauthLoginController.php
+++ b/app/Http/Controllers/Auth/OauthLoginController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
+use Log;
 use App\Models\LogEntry;
 use App\Http\Controllers\Controller;
 use App\Models\User;
@@ -31,6 +32,12 @@ class OauthLoginController extends Controller
         // helps mainly for development stuff, when loading permissions fails
         $user = DB::transaction(function () use ($request) {
             $socialiteUser = Socialite::driver('mediawiki')->user();
+
+            // sanity check
+            if (!$socialiteUser->getId() || !$socialiteUser->getName()) {
+                Log::error('OAuth failed: MediaWiki api returned an invalid user object ' . json_encode($socialiteUser));
+                abort(500);
+            }
 
             $user = User::firstWhere([
                 'username' => $socialiteUser->getName(),

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "laravel/tinker": "^2.5",
         "laravelcollective/html": "^6.1",
         "spatie/laravel-backup": "^6.10",
-        "taavi/laravel-socialite-mediawiki": "^1.2",
+        "taavi/laravel-socialite-mediawiki": "^1.3",
         "wikimedia/ip-utils": "^3.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49fd70dcf8f91b6d8d21ed91879ce9af",
+    "content-hash": "573a3d95ad26d705128707415bae724d",
     "packages": [
         {
             "name": "addwiki/mediawiki-api",
@@ -5428,19 +5428,20 @@
         },
         {
             "name": "taavi/laravel-socialite-mediawiki",
-            "version": "1.2.2",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/supertassu/laravel-socialite-mediawiki.git",
-                "reference": "628b3df681707ebc2888d1c25801de708efb23d3"
+                "reference": "9a3b8d6d1e861e2a5a6313c6db0ea3e1b695b22d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/supertassu/laravel-socialite-mediawiki/zipball/628b3df681707ebc2888d1c25801de708efb23d3",
-                "reference": "628b3df681707ebc2888d1c25801de708efb23d3",
+                "url": "https://api.github.com/repos/supertassu/laravel-socialite-mediawiki/zipball/9a3b8d6d1e861e2a5a6313c6db0ea3e1b695b22d",
+                "reference": "9a3b8d6d1e861e2a5a6313c6db0ea3e1b695b22d",
                 "shasum": ""
             },
             "require": {
+                "ext-json": "*",
                 "laravel/socialite": "^4.4|^5.0",
                 "php": "^7.0"
             },
@@ -5470,9 +5471,9 @@
             "description": "A MediaWiki authentication provider for Laravel Socialite",
             "support": {
                 "issues": "https://github.com/supertassu/laravel-socialite-mediawiki/issues",
-                "source": "https://github.com/supertassu/laravel-socialite-mediawiki/tree/1.2.2"
+                "source": "https://github.com/supertassu/laravel-socialite-mediawiki/tree/1.3.0"
             },
-            "time": "2020-09-24T08:19:54+00:00"
+            "time": "2020-11-24T15:02:40+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",

--- a/database/migrations/2020_11_24_164007_add_central_ids_to_users_table.php
+++ b/database/migrations/2020_11_24_164007_add_central_ids_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCentralIdsToUsersTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedBigInteger('mediawiki_id')
+                ->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('mediawiki_id');
+        });
+    }
+}

--- a/resources/views/admin/users/view.blade.php
+++ b/resources/views/admin/users/view.blade.php
@@ -36,6 +36,10 @@
                     <td>{{ $user->username }}</td>
                 </tr>
                 <tr>
+                    <th>CentralAuth ID</th>
+                    <td>{{ $user->mediawiki_id ?? '(not known)' }}</td>
+                </tr>
+                <tr>
                     <th>Last Permission Check</th>
                     <td>{{ $user->last_permission_check_at }}</td>
                 </tr>


### PR DESCRIPTION
JWT `sub` claim contains the user's CentralAuth ID when available, otherwise it falls back to local user ID[1]. That allows us to use that as an unique user ID that persists across wikis.

Also drop default value for the user.wikis column for new users.

closes #227
see #322

[1] https://github.com/wikimedia/mediawiki-extensions-OAuth/blob/2ae40d2a53548cba1413ec8f765000548f133587/src/Backend/Utils.php#L300