### PR TITLE
Fix commenting

### DIFF
--- a/resources/views/appeals/appeal.blade.php
+++ b/resources/views/appeals/appeal.blade.php
@@ -416,7 +416,7 @@
                         </div>
                         <div class="col-md-6">
                             <h5 class="card-title">Drop a comment</h5>
-                            {{ Form::open(['url' => '/appeal/comment/' . $id]) }}
+                            {{ Form::open(['url' => route('appeal.action.comment', $info)]) }}
                                 {{ Form::token() }}
 
                                 <div class="form-group">

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,8 +36,8 @@ Route::get('/review', 'AppealController@appeallist')->name('appeal.list');
 Route::get('/locate', 'AppealController@search')->name('appeal.search');
 
 Route::post('/appeal/checkuser/{appeal}', 'AppealController@checkuser')->name('appeal.action.viewcheckuser');
-Route::post('/appeal/comment/{id}', 'AppealController@comment');
-Route::get('/appeal/respond/{id}', 'AppealController@respond');
+Route::post('/appeal/comment/{appeal}', 'AppealController@comment')->name('appeal.action.comment');
+Route::get('/appeal/respond/{appeal}', 'AppealController@respond');
 
 Route::post('/appeal/reserve/{appeal}', 'Appeal\AppealActionController@reserve')->name('appeal.action.reserve');
 Route::post('/appeal/release/{appeal}', 'Appeal\AppealActionController@release')->name('appeal.action.release');

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,7 +37,6 @@ Route::get('/locate', 'AppealController@search')->name('appeal.search');
 
 Route::post('/appeal/checkuser/{appeal}', 'AppealController@checkuser')->name('appeal.action.viewcheckuser');
 Route::post('/appeal/comment/{appeal}', 'AppealController@comment')->name('appeal.action.comment');
-Route::get('/appeal/respond/{appeal}', 'AppealController@respond');
 
 Route::post('/appeal/reserve/{appeal}', 'Appeal\AppealActionController@reserve')->name('appeal.action.reserve');
 Route::post('/appeal/release/{appeal}', 'Appeal\AppealActionController@release')->name('appeal.action.release');

--- a/tests/Feature/Appeal/Action/AppealCommentTest.php
+++ b/tests/Feature/Appeal/Action/AppealCommentTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature\Appeal\Action;
+
+use App\Models\Appeal;
+
+/**
+ * @covers \App\Http\Controllers\AppealController::comment
+ */
+class AppealCommentTest extends BaseAppealActionTest
+{
+    public function testCanAddPrivateComment()
+    {
+        $user = $this->getUser();
+        $appeal = Appeal::factory()->create([ 'status' => Appeal::STATUS_OPEN, ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->post(route('appeal.action.comment', $appeal), [
+                'comment' => 'example comment',
+            ]);
+        $response->assertRedirect(route('appeal.view', $appeal));
+
+        $appeal->refresh();
+        $this->assertEquals(Appeal::STATUS_OPEN, $appeal->status);
+        $this->assertTrue($appeal->comments()
+            ->where('action', 'comment')
+            ->where('user_id', $user->id)
+            ->where('reason', 'example comment')
+            ->exists());
+    }
+}


### PR DESCRIPTION
closes #394

I'm not exactly sure what the `/appeal/respond/{appeal}` route is used for, it should be affected by the same bug - but I didn't find any uses of that route outside `routes/web.php`.