### PR TITLE
Fix requesting CheckUser information

### DIFF
--- a/resources/views/appeals/appeal.blade.php
+++ b/resources/views/appeals/appeal.blade.php
@@ -74,7 +74,7 @@
                                     <div class="alert alert-danger" role="alert">
                                         You have not submitted a request to view the CheckUser data yet.
                                     </div>
-                                    {{ Form::open(['url' => route('appeal.action.checkuser', $info)]) }}
+                                    {{ Form::open(['url' => route('appeal.action.viewcheckuser', $info)]) }}
                                         {{ Form::token() }}
 
                                         <div class="form-group">
@@ -446,7 +446,7 @@
                         <span aria-hidden="true">&times;</span>
                     </button>
                 </div>
-                {{ Form::open(['url' => route('appeal.action.checkuser', $info)]) }}
+                {{ Form::open(['url' => route('appeal.action.requestcheckuser', $info)]) }}
                 {{ Form::token() }}
                 <div class="modal-body">
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,7 +46,7 @@ Route::post('/appeal/release/{appeal}', 'Appeal\AppealActionController@release')
 Route::post('/appeal/open/{appeal}', 'Appeal\AppealActionController@reOpen')->name('appeal.action.reopen');
 Route::post('/appeal/findagain/{appeal}', 'Appeal\AppealActionController@reverifyBlockDetails')->name('appeal.action.findagain');
 Route::post('/appeal/close/{appeal}/{type}', 'Appeal\AppealActionController@close')->name('appeal.action.close');
-Route::post('/appeal/checkuserreview/{appeal}', 'Appeal\AppealActionController@sendToCheckUserReview')->name('appeal.action.checkuser');
+Route::post('/appeal/checkuserreview/{appeal}', 'Appeal\AppealActionController@sendToCheckUserReview')->name('appeal.action.requestcheckuser');
 Route::post('/appeal/tooladmin/{appeal}', 'Appeal\AppealActionController@sendToTooladminReview')->name('appeal.action.tooladmin');
 Route::post('/appeal/invalidate/{appeal}', 'Appeal\AppealActionController@invalidate')->name('appeal.action.invalidate');
 

--- a/tests/Feature/Appeal/Action/AppealReferTest.php
+++ b/tests/Feature/Appeal/Action/AppealReferTest.php
@@ -31,7 +31,7 @@ class AppealReferTest extends BaseAppealActionTest
 
         $response = $this
             ->actingAs($user)
-            ->post(route('appeal.action.checkuser', $appeal), [
+            ->post(route('appeal.action.requestcheckuser', $appeal), [
                 'cu_reason' => 'Example CheckUser reason',
             ]);
         $response->assertRedirect();
@@ -52,7 +52,7 @@ class AppealReferTest extends BaseAppealActionTest
 
         $response = $this
             ->actingAs($user)
-            ->post(route('appeal.action.checkuser', $appeal));
+            ->post(route('appeal.action.requestcheckuser', $appeal));
         $response->assertSessionHasErrors('cu_reason');
 
         $appeal->refresh();


### PR DESCRIPTION


As reported by SQL on IRC, the appeal CheckUser function does not work.
Turns out the form was pointing at the endpoint for requesting CU
review. Fix that and change the route names to hopefully not cause this
in the future.

