### PR TITLE
Fix logging in to MW api

### DIFF
--- a/app/Jobs/Scheduled/UpdateWikiAppealListJob.php
+++ b/app/Jobs/Scheduled/UpdateWikiAppealListJob.php
@@ -82,7 +82,10 @@ class UpdateWikiAppealListJob implements ShouldQueue
         $text = $this->createContents($appeals);
 
         // get page information
-        $services = MediaWikiRepository::getApiForTarget($this->wiki)->getAddWikiServices();
+        $api = MediaWikiRepository::getApiForTarget($this->wiki);
+        $api->login();
+
+        $services = $api->getAddWikiServices();
         $page = $services->newPageGetter()->getFromTitle($page);
 
         // prepare edit

--- a/app/Services/MediaWiki/Api/MediaWikiApi.php
+++ b/app/Services/MediaWiki/Api/MediaWikiApi.php
@@ -14,4 +14,6 @@ interface MediaWikiApi
     public function getAddWikiServices(): MediawikiFactory;
 
     public function getMediaWikiExtras(): MediaWikiExtras;
+
+    public function login(): void;
 }

--- a/app/Services/MediaWiki/Implementation/RealMediaWikiApi.php
+++ b/app/Services/MediaWiki/Implementation/RealMediaWikiApi.php
@@ -35,7 +35,11 @@ class RealMediaWikiApi implements MediaWikiApi
 
         /** @var CookieJar $jar */
         $jar = $this->guzzleClient->getConfig('cookies');
-        if ($jar->getCookieByName('mediawiki_session')) {
+
+        // session names are unreliable, just assume there is at least some session if it's not empty
+        // checking the logged-in status when logging in isn't that expensive and this is significantly
+        // simpler than trying to guess the correct session cookie name which can change at any point anyways
+        if ($jar->count() > 0) {
             $this->hasExistingSession = true;
         }
     }
@@ -69,7 +73,7 @@ class RealMediaWikiApi implements MediaWikiApi
         return new RealMediaWikiExtras($this);
     }
 
-    public function login()
+    public function login(): void
     {
         if ($this->loggedIn) {
             return;

--- a/tests/Fakes/MediaWiki/FakeMediaWikiApi.php
+++ b/tests/Fakes/MediaWiki/FakeMediaWikiApi.php
@@ -46,4 +46,9 @@ class FakeMediaWikiApi implements MediaWikiApi
     {
         return $this->wiki;
     }
+
+    public function login(): void
+    {
+        // no-op
+    }
 }


### PR DESCRIPTION
Actually log in when updating the appeal table.

Make the existing session detection logic better.

closes #432 
