### PR TITLE
Always allow not changing appeal status when responding

### DIFF
--- a/app/Http/Controllers/AppealController.php
+++ b/app/Http/Controllers/AppealController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Rules\PermittedStatusChange;
 use App\Models\Appeal;
 use App\Models\LogEntry;
 use App\Models\Wiki;
@@ -216,12 +217,12 @@ class AppealController extends Controller
 
         abort_unless($appeal->handlingadmin === $user->id, 403, 'You are not the handling administrator.');
 
-        $ua = $request->server('HTTP_USER_AGENT');
+        $ua = $request->userAgent();
         $ip = $request->ip();
-        $lang = $request->server('HTTP_ACCEPT_LANGUAGE');
+        $lang = $request->header('Accept-Language');
 
         $status = $request->validate([
-            'status' => ['nullable', Rule::in(Appeal::REPLY_STATUS_CHANGE_OPTIONS)],
+            'status' => ['nullable', new PermittedStatusChange($appeal)],
         ])['status'];
 
         if ($status && $status !== $appeal->status) {
@@ -262,7 +263,7 @@ class AppealController extends Controller
         abort_unless($appeal->handlingadmin === $user->id, 403, 'You are not the handling administrator.');
 
         $status = $request->validate([
-            'status' => ['nullable', Rule::in(Appeal::REPLY_STATUS_CHANGE_OPTIONS)],
+            'status' => ['nullable', new PermittedStatusChange($appeal)],
         ])['status'];
 
         $ua = $request->userAgent();

--- a/app/Http/Rules/PermittedStatusChange.php
+++ b/app/Http/Rules/PermittedStatusChange.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Rules;
+
+use App\Models\Appeal;
+use Illuminate\Contracts\Validation\Rule;
+
+class PermittedStatusChange implements Rule
+{
+    /** @var Appeal */
+    private $appeal;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @param Appeal $appeal
+     */
+    public function __construct(Appeal $appeal)
+    {
+        $this->appeal = $appeal;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value): bool
+    {
+        return $this->appeal->isValidStatusChange($value);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message(): string
+    {
+        return 'The new value for :attribute is not permitted for this appeal.';
+    }
+}

--- a/app/Models/Appeal.php
+++ b/app/Models/Appeal.php
@@ -125,6 +125,34 @@ class Appeal extends Model
 
     // other functions
 
+    /**
+     * Check if the specified value can be used as a new status.
+     * @param string $newStatus
+     * @return bool
+     */
+    public function isValidStatusChange(string $newStatus): bool
+    {
+        return in_array($newStatus, $this->getValidStatusChanges());
+    }
+
+    /**
+     * @return string[] all allowed status changes for this appeal
+     */
+    public function getValidStatusChanges(): array
+    {
+        $values = self::REPLY_STATUS_CHANGE_OPTIONS;
+
+        // When in a status not normally possible to use in templates (like checkuser),
+        // allow not modifying the status.
+        // https://github.com/UTRS2/utrs/issues/455
+        if (!isset($values[$this->status])) {
+            // set key too, so this data can be directly fed to the html form dropdown generator
+            $values[$this->status] = $this->status;
+        }
+
+        return $values;
+    }
+
     public function getFormattedBlockReason($linkExtra = '')
     {
         if (!$this->blockreason || strlen($this->blockreason) === 0) {

--- a/resources/views/appeals/custom.blade.php
+++ b/resources/views/appeals/custom.blade.php
@@ -26,7 +26,7 @@
             <div class="card-body">
                 <div class="form-group">
                     {{ Form::label('status', 'Change appeal status to:') }}
-                    {{ Form::select('status', \App\Models\Appeal::REPLY_STATUS_CHANGE_OPTIONS, old('status', $appeal->status), ['class' => 'form-control']) }}
+                    {{ Form::select('status', $appeal->getValidStatusChanges(), old('status', $appeal->status), ['class' => 'form-control']) }}
                 </div>
             </div>
         </div>

--- a/resources/views/appeals/templates.blade.php
+++ b/resources/views/appeals/templates.blade.php
@@ -34,7 +34,7 @@
                 {{ Form::open(['url' => route('appeal.template.submit', [$appeal, $template])]) }}
                 <div class="form-group">
                     {{ Form::label("status-" . $template->id, 'Change appeal status to:') }}
-                    {{ Form::select('status', \App\Models\Appeal::REPLY_STATUS_CHANGE_OPTIONS, old('status', $template->default_status), ['class' => 'form-control', 'id' => "status-" . $template->id]) }}
+                    {{ Form::select('status', $appeal->getValidStatusChanges(), old('status', $template->default_status), ['class' => 'form-control', 'id' => "status-" . $template->id]) }}
                 </div>
 
                 <button type="submit" class="btn btn-success">Submit</button>


### PR DESCRIPTION
Fix a bug where responding to an appeal in a queue status (like
CHECKUSER or ADMIN) would forcibly change the appeal back to OPEN
status.

closes #455
