### PR TITLE
db optimizations

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -98,7 +98,7 @@ class UserController extends Controller
                 if (!empty($updateSet)) {
                     if (!$permission) {
                         $permission = new Permission();
-                        $permission->userid = $user->id;
+                        $permission->user_id = $user->id;
                         $permission->wiki = $wikiDbName;
                     }
 

--- a/app/Http/Controllers/Appeal/PublicAppealController.php
+++ b/app/Http/Controllers/Appeal/PublicAppealController.php
@@ -73,7 +73,7 @@ class PublicAppealController extends Controller
             $appeal = Appeal::create($data);
 
             Privatedata::create([
-                'appealID'  => $appeal->id,
+                'appeal_id' => $appeal->id,
                 'ipaddress' => $ip,
                 'useragent' => $ua,
                 'language'  => $lang,

--- a/app/Http/Controllers/AppealController.php
+++ b/app/Http/Controllers/AppealController.php
@@ -55,7 +55,7 @@ class AppealController extends Controller
 
             $logs = $info->comments;
 
-            $cudata = Privatedata::where('appealID', '=', $id)->get()->first();
+            $cudata = Privatedata::where('appeal_id', '=', $id)->get()->first();
 
             $perms = [];
             $perms['checkuser'] = $user->can('viewCheckUserInformation', $info);

--- a/app/Jobs/LoadPermissionsJob.php
+++ b/app/Jobs/LoadPermissionsJob.php
@@ -48,7 +48,7 @@ class LoadPermissionsJob implements ShouldQueue, ShouldBeUnique
             $groups = $checker->getUserGroups($this->user->username);
 
             $permObject = Permission::firstOrNew([
-                'userid' => $this->user->id,
+                'user_id' => $this->user->id,
                 'wiki' => $wiki,
             ]);
 

--- a/app/Models/Appeal.php
+++ b/app/Models/Appeal.php
@@ -120,7 +120,7 @@ class Appeal extends Model
 
     public function privateData()
     {
-        return $this->hasOne(Privatedata::class, 'appealID', 'id');
+        return $this->hasOne(Privatedata::class, 'appeal_id', 'id');
     }
 
     // other functions

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -29,7 +29,7 @@ class Permission extends Model
 
     public function userObject()
     {
-        return $this->belongsTo(User::class, 'userid');
+        return $this->belongsTo(User::class, 'user_id');
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -49,7 +49,7 @@ class User extends Authenticatable
 
     public function permissions()
     {
-        return $this->hasMany(Permission::class, 'userid', 'id');
+        return $this->hasMany(Permission::class, 'user_id', 'id');
     }
 
     /**

--- a/database/factories/PrivatedataFactory.php
+++ b/database/factories/PrivatedataFactory.php
@@ -21,10 +21,10 @@ class PrivatedataFactory extends Factory
         $this->faker->addProvider(new AcceptLanguageFakerProvider($this->faker));
 
         return [
-            'appealID' => $this->faker->numberBetween(1, Appeal::count()),
+            'appeal_id' => $this->faker->numberBetween(1, Appeal::count()),
             'ipaddress' => $this->faker->ipv4,
             'useragent' => $this->faker->userAgent,
-            'language' => $this->faker->acceptLanguage,
+            'language'  => $this->faker->acceptLanguage,
         ];
     }
 }

--- a/database/migrations/2021_10_17_101414_add_model_index_to_log_entries.php
+++ b/database/migrations/2021_10_17_101414_add_model_index_to_log_entries.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddModelIndexToLogEntries extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('log_entries', function (Blueprint $table) {
+            $table->index(['model_type', 'model_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('log_entries', function (Blueprint $table) {
+            $table->dropIndex(['model_type', 'model_id']);
+        });
+    }
+}

--- a/database/migrations/2021_10_17_102327_rename_appeal_id_on_private_data.php
+++ b/database/migrations/2021_10_17_102327_rename_appeal_id_on_private_data.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameAppealIdOnPrivateData extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('privatedatas', function (Blueprint $table) {
+            $table->renameColumn('appealID', 'appeal_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('privatedatas', function (Blueprint $table) {
+            $table->renameColumn('appeal_id', 'appealID');
+        });
+    }
+}

--- a/database/migrations/2021_10_17_103050_fix_appeal_id_type_on_private_data.php
+++ b/database/migrations/2021_10_17_103050_fix_appeal_id_type_on_private_data.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class FixAppealIdTypeOnPrivateData extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('privatedatas', function (Blueprint $table) {
+            $table->unsignedBigInteger('appeal_id')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('privatedatas', function (Blueprint $table) {
+            $table->bigInteger('appeal_id')->change();
+        });
+    }
+}

--- a/database/migrations/2021_10_17_103112_add_foreign_appeal_id_on_private_data.php
+++ b/database/migrations/2021_10_17_103112_add_foreign_appeal_id_on_private_data.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForeignAppealIdOnPrivateData extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('privatedatas', function (Blueprint $table) {
+            $table->foreign('appeal_id')
+                ->references('id')
+                ->on('appeals')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('privatedatas', function (Blueprint $table) {
+            $table->dropForeign(['appeal_id']);
+        });
+    }
+}

--- a/database/migrations/2021_10_17_103427_remove_permissions_for_nonexistent_users.php
+++ b/database/migrations/2021_10_17_103427_remove_permissions_for_nonexistent_users.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RemovePermissionsForNonexistentUsers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Clean up leftovers of any deleted users
+        DB::table('permissions')
+            ->whereNotIn(
+                'userid',
+                DB::table('users')
+                    ->select('id')
+                    ->distinct()
+                    ->get()
+            )
+            ->delete();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Nothing left here
+    }
+}

--- a/database/migrations/2021_10_17_103549_rename_user_id_on_permissions.php
+++ b/database/migrations/2021_10_17_103549_rename_user_id_on_permissions.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameUserIdOnPermissions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->renameColumn('userid', 'user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->renameColumn('user_id', 'userid');
+        });
+    }
+}

--- a/database/migrations/2021_10_17_103634_fix_user_id_type_on_permissions.php
+++ b/database/migrations/2021_10_17_103634_fix_user_id_type_on_permissions.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class FixUserIdTypeOnPermissions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->change();
+        });
+    }
+}

--- a/database/migrations/2021_10_17_103645_add_foreign_user_id_on_permissions.php
+++ b/database/migrations/2021_10_17_103645_add_foreign_user_id_on_permissions.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForeignUserIdOnPermissions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+        });
+    }
+}

--- a/database/seeders/UserSeed.php
+++ b/database/seeders/UserSeed.php
@@ -28,7 +28,7 @@ class UserSeed extends Seeder
 
         if ($grantDeveloper) {
             Permission::create([
-                'userid' => $user->id,
+                'user_id' => $user->id,
                 'developer' => 1,
                 'wiki' => '*',
             ]);
@@ -42,7 +42,7 @@ class UserSeed extends Seeder
     {
         foreach (explode(' ', $wikis) as $wiki) {
             Permission::firstOrCreate([
-                'userid' => $user->id,
+                'user_id' => $user->id,
                 'wiki' => $wiki,
             ])->update([
                 $permission => 1,

--- a/tests/Feature/Appeal/Action/ActionAppealCheckUserTest.php
+++ b/tests/Feature/Appeal/Action/ActionAppealCheckUserTest.php
@@ -57,7 +57,7 @@ class ActionAppealCheckUserTest extends BaseAppealActionTest
         $appeal = Appeal::factory()->create();
 
         Privatedata::factory()->create([
-            'appealID' => $appeal->id,
+            'appeal_id' => $appeal->id,
         ]);
 
         $response = $this
@@ -77,7 +77,7 @@ class ActionAppealCheckUserTest extends BaseAppealActionTest
         $user = $this->getFunctionaryTooladminUser();
         $appeal = Appeal::factory()->create();
         Privatedata::factory()->create([
-            'appealID' => $appeal->id,
+            'appeal_id' => $appeal->id,
             'useragent' => 'Example string to look out for!!!',
         ]);
 

--- a/tests/Traits/TestHasUsers.php
+++ b/tests/Traits/TestHasUsers.php
@@ -37,7 +37,7 @@ trait TestHasUsers
                 ->toArray();
 
             Permission::firstOrCreate([
-                'userid' => $user->id,
+                'user_id' => $user->id,
                 'wiki' => $wiki,
             ], $toSet);
         }


### PR DESCRIPTION
This PR adds additional [database indexes](https://en.wikipedia.org/wiki/Database_index) to hopefully improve performance.

So:
* Logs are now indexed by `(model_type, model_id)`, which should speed up log queries since practically all access is done for a single model like that.
* Appeal private data table had `appealID` column renamed to `appeal_id` (since that form is more familiar within Laravel) and had a foreign key index added linking private data objects to appeals.
* Similarly, permissions table had `userid` renamed to `user_id` with a foreign key index added.

Appeals table is not touched yet as I want to get the wiki ID refactoring done first.