### PR TITLE
appeals: Store wiki id alongside name

### DIFF
--- a/app/Http/Controllers/Appeal/PublicAppealCreateController.php
+++ b/app/Http/Controllers/Appeal/PublicAppealCreateController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Appeal;
+
+use App\Http\Controllers\Controller;
+use App\Models\Wiki;
+
+class PublicAppealCreateController extends Controller
+{
+    private function createWikiDropdown()
+    {
+        return Wiki::where('is_accepting_appeals', true)
+            ->get()
+            ->mapWithKeys(function (Wiki $wiki) {
+                return [$wiki->id => $wiki->display_name];
+            });
+    }
+
+    public function showIpForm()
+    {
+        return view(
+            'appeals.public.makeappeal.ip',
+            ['wikis' => $this->createWikiDropdown()]
+        );
+    }
+
+    public function showAccountForm()
+    {
+        return view(
+            'appeals.public.makeappeal.account',
+            ['wikis' => $this->createWikiDropdown()]
+        );
+    }
+}

--- a/app/Http/Controllers/AppealController.php
+++ b/app/Http/Controllers/AppealController.php
@@ -305,9 +305,7 @@ class AppealController extends Controller
         $this->authorize('update', $appeal);
 
         $templates = Template::where('active', true)
-            ->whereHas('wiki', function (Builder $query) use ($appeal) {
-                $query->where('database_name', $appeal->wiki);
-            })
+            ->where('wiki_id', $appeal->wiki_id)
             ->get();
 
         return view('appeals.templates', ['templates' => $templates, 'appeal' => $appeal, 'username' => $request->user()->username]);

--- a/app/Jobs/GetBlockDetailsJob.php
+++ b/app/Jobs/GetBlockDetailsJob.php
@@ -86,7 +86,7 @@ class GetBlockDetailsJob implements ShouldQueue
 
             $banTargets = Ban::getTargetsToCheck($this->appeal->appealfor);
             $ban = Ban::whereIn('target', $banTargets)
-                ->wikiNameOrGlobal($this->appeal->wiki)
+                ->wikiIdOrGlobal($this->appeal->wiki_id)
                 ->active()
                 ->first();
 

--- a/app/Models/Ban.php
+++ b/app/Models/Ban.php
@@ -50,14 +50,12 @@ class Ban extends Model
     /**
      * Scope the query to only search for bans that are either global on in the specified wiki.
      */
-    public function scopeWikiNameOrGlobal(Builder $query, string $wiki)
+    public function scopeWikiIdOrGlobal(Builder $query, int $wikiId)
     {
         return $query
-            ->where(function (Builder $query) use ($wiki) {
+            ->where(function (Builder $query) use ($wikiId) {
                 return $query
-                    ->whereHas('wiki', function (Builder $query) use ($wiki) {
-                        return $query->where('database_name', $wiki);
-                    })
+                    ->where('wiki_id', $wikiId)
                     ->orWhereNull('wiki_id');
             });
     }

--- a/app/Services/MediaWiki/Api/MediaWikiRepository.php
+++ b/app/Services/MediaWiki/Api/MediaWikiRepository.php
@@ -36,12 +36,6 @@ interface MediaWikiRepository
     public function getGlobalApi(): MediaWikiApi;
 
     /**
-     * Provides an array that can be used to build a dropdown for all available wikis.
-     * @return array Array with [dbName => Human readable name] pairs for all available wikis
-     */
-    public function getWikiDropdown(): array;
-
-    /**
      * @param string $wiki
      * @return WikiPermissionHandler
      */

--- a/app/Services/MediaWiki/Implementation/RealMediaWikiRepository.php
+++ b/app/Services/MediaWiki/Implementation/RealMediaWikiRepository.php
@@ -65,21 +65,6 @@ class RealMediaWikiRepository implements MediaWikiRepository
         return $this->getApiForTarget('global');
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getWikiDropdown(): array
-    {
-        return collect($this->getSupportedTargets())
-            ->filter(function ($wiki) {
-                return !$this->getTargetProperty($wiki, 'hidden_from_appeal_wiki_list', false);
-            })
-            ->mapWithKeys(function ($wiki) {
-                return [$wiki => $this->getTargetProperty($wiki, 'name')];
-            })
-            ->toArray();
-    }
-
     public function getWikiPermissionHandler(string $wiki): WikiPermissionHandler
     {
         if (!array_key_exists($wiki, $this->loadedPermissionHandlers)) {

--- a/database/factories/AppealFactory.php
+++ b/database/factories/AppealFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Appeal;
+use App\Models\Wiki;
 use App\Services\Facades\MediaWikiRepository;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -22,6 +23,9 @@ class AppealFactory extends Factory
      */
     public function definition()
     {
+        // first because many tests (sadly) assume that ://
+        $wiki = Wiki::first();
+
         return [
             'appealfor' => $this->faker->firstName,
             'blocktype' => 1,
@@ -32,7 +36,8 @@ class AppealFactory extends Factory
             'submitted' => $this->faker->dateTimeBetween('-3 days', '-1 hour'),
             'appealsecretkey' => implode('', $this->faker->words()),
             'appealtext' => $this->faker->sentence,
-            'wiki' => MediaWikiRepository::getSupportedTargets(false)[0],
+            'wiki' => $wiki->database_name,
+            'wiki_id' => $wiki->id,
             'user_verified' => 0,
         ];
     }

--- a/database/migrations/2021_10_17_092756_add_wiki_id_to_appeals.php
+++ b/database/migrations/2021_10_17_092756_add_wiki_id_to_appeals.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddWikiIdToAppeals extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('appeals', function (Blueprint $table) {
+            $table->unsignedBigInteger('wiki_id')
+                ->nullable(true);
+
+            $table->foreign('wiki_id')
+                ->references('id')
+                ->on('wikis');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('appeals', function (Blueprint $table) {
+            $table->dropForeign(['wiki_id']);
+            $table->dropColumn('wiki_id');
+        });
+    }
+}

--- a/database/migrations/2021_10_17_092836_backfill_wiki_ids_to_appeals.php
+++ b/database/migrations/2021_10_17_092836_backfill_wiki_ids_to_appeals.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\Appeal;
+use Illuminate\Database\Migrations\Migration;
+
+class BackfillWikiIdsToAppeals extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::table('appeals')
+            ->select(['appeals.wiki', 'wikis.id'])->distinct()
+            ->join('wikis', 'wikis.database_name', '=', 'appeals.wiki')
+            ->get()
+            ->each(function ($entry) {
+                DB::table('appeals')
+                    ->where('wiki', $entry->wiki)
+                    ->update([
+                        'wiki_id' => $entry->id,
+                    ]);
+            });
+
+        if (Appeal::whereNull('wiki_id')->count() !== 0) {
+            // Check just in case, before the next migration drops the database names
+            throw new RuntimeException('Failed to backfill wiki_id to all appeals');
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::table('appeals')
+            ->update([
+                'wiki_id' => null,
+            ]);
+    }
+}

--- a/database/migrations/2021_10_18_082249_make_wiki_id_not_nullable_on_appeals.php
+++ b/database/migrations/2021_10_18_082249_make_wiki_id_not_nullable_on_appeals.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class MakeWikiIdNotNullableOnAppeals extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('appeals', function (Blueprint $table) {
+            $table->unsignedBigInteger('wiki_id')
+                ->nullable(false)
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('appeals', function (Blueprint $table) {
+            $table->unsignedBigInteger('wiki_id')
+                ->nullable(true)
+                ->change();
+        });
+    }
+}

--- a/resources/views/appeals/public/makeappeal/account.blade.php
+++ b/resources/views/appeals/public/makeappeal/account.blade.php
@@ -34,8 +34,8 @@
             {{ Form::token() }}
             <h5>{{ __('appeals.forms.about-you') }}</h5>
             <div class="form-group mb-4">
-                {{ Form::label('wiki', __('appeals.forms.block-wiki')) }}<br>
-                {{ Form::select('wiki', \App\Services\Facades\MediaWikiRepository::getWikiDropdown(), old('wiki', 'enwiki'), ['class' => 'custom-select']) }}
+                {{ Form::label('wiki_id', __('appeals.forms.block-wiki')) }}<br>
+                {{ Form::select('wiki_id', $wikis, old('wiki_id'), ['class' => 'custom-select']) }}
             </div>
             <div class="form-group mb-4">
                 {{ Form::label('appealfor', __('appeals.forms.block-username')) }}

--- a/resources/views/appeals/public/makeappeal/ip.blade.php
+++ b/resources/views/appeals/public/makeappeal/ip.blade.php
@@ -33,8 +33,8 @@
 
             <h5>About you</h5>
             <div class="form-group mb-4">
-                {{ Form::label('wiki', __('appeals.forms.block-wiki')) }}<br>
-                {{ Form::select('wiki', \App\Services\Facades\MediaWikiRepository::getWikiDropdown(), old('wiki', 'enwiki'), ['class' => 'custom-select']) }}
+                {{ Form::label('wiki_id', __('appeals.forms.block-wiki')) }}<br>
+                {{ Form::select('wiki_id', $wikis, old('wiki_id'), ['class' => 'custom-select']) }}
             </div>
             {{ Form::hidden('blocktype', 0) }}
 

--- a/resources/views/appeals/public/modify.blade.php
+++ b/resources/views/appeals/public/modify.blade.php
@@ -18,8 +18,8 @@
             {{ Form::open(['url' => route('public.appeal.modify.submit')]) }}
             {{ Form::token() }}
             <div class="form-group mb-4">
-                {{ Form::label('wiki', __('appeals.forms.block-wiki')) }}<br>
-                {{ Form::select('wiki', \App\Services\Facades\MediaWikiRepository::getWikiDropdown(), old('wiki', $appeal->wiki), ['class' => 'custom-select']) }}
+                {{ Form::label('wiki_id', __('appeals.forms.block-wiki')) }}<br>
+                {{ Form::select('wiki_id', $wikis, old('wiki_id'), ['class' => 'custom-select']) }}
             </div>
 
             <div class="form-group mb-4">

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,11 +15,11 @@ Route::view('/', 'home')->name('home');
 Route::redirect('/home', '/');
 
 Route::prefix('/public')->middleware('guest')->group(function () {
-    Route::view('/appeal/ip', 'appeals.public.makeappeal.ip')
+    Route::get('/appeal/ip', 'Appeal\PublicAppealCreateController@showIpForm')
         ->name('public.appeal.create.ip')
         ->middleware('torblock');
 
-    Route::view('/appeal/account', 'appeals.public.makeappeal.account')
+    Route::get('/appeal/account', 'Appeal\PublicAppealCreateController@showAccountForm')
         ->name('public.appeal.create.account')
         ->middleware('torblock');
 

--- a/tests/Feature/Appeal/AppealCreateBanTest.php
+++ b/tests/Feature/Appeal/AppealCreateBanTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\Appeal;
 
 use App\Models\Ban;
 use App\Models\Wiki;
-use App\Services\Facades\MediaWikiRepository;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Tests\TestCase;
 
@@ -14,8 +13,7 @@ class AppealCreateBanTest extends TestCase
 
     public function test_can_create_appeal_when_not_banned()
     {
-        $wikiId = Wiki::where('database_name', MediaWikiRepository::getSupportedTargets()[0])
-            ->firstOrFail()->id;
+        $wikiId = Wiki::firstOrFail()->id;
 
         Ban::factory()->create([
             'is_active' => true,
@@ -28,7 +26,7 @@ class AppealCreateBanTest extends TestCase
             'test_do_not_actually_save_anything' => true,
             'appealtext' => 'Example appeal test',
             'appealfor' => 'Not banned user',
-            'wiki' => MediaWikiRepository::getSupportedTargets()[0],
+            'wiki_id' => $wikiId,
             'blocktype' => 1,
         ]);
 
@@ -38,8 +36,7 @@ class AppealCreateBanTest extends TestCase
 
     public function test_cant_create_appeal_when_account_is_banned()
     {
-        $wikiId = Wiki::where('database_name', MediaWikiRepository::getSupportedTargets()[0])
-            ->firstOrFail()->id;
+        $wikiId = Wiki::firstOrFail()->id;
 
         Ban::factory()->create([
             'is_active' => true,
@@ -52,7 +49,7 @@ class AppealCreateBanTest extends TestCase
             'test_do_not_actually_save_anything' => true,
             'appealtext' => 'Example appeal test',
             'appealfor' => 'Banned user 1',
-            'wiki' => MediaWikiRepository::getSupportedTargets()[0],
+            'wiki_id' => $wikiId,
             'blocktype' => 1,
         ]);
 
@@ -62,8 +59,7 @@ class AppealCreateBanTest extends TestCase
 
     public function test_cant_create_appeal_when_current_ip_is_banned()
     {
-        $wikiId = Wiki::where('database_name', MediaWikiRepository::getSupportedTargets()[0])
-            ->firstOrFail()->id;
+        $wikiId = Wiki::firstOrFail()->id;
 
         Ban::factory()->create([
             'is_active' => true,
@@ -85,7 +81,7 @@ class AppealCreateBanTest extends TestCase
             'test_do_not_actually_save_anything' => true,
             'appealtext' => 'Example appeal test',
             'appealfor' => 'Not banned user',
-            'wiki' => MediaWikiRepository::getSupportedTargets()[0],
+            'wiki_id' => $wikiId,
             'blocktype' => 1,
         ]);
 
@@ -95,8 +91,7 @@ class AppealCreateBanTest extends TestCase
 
     public function test_cant_create_appeal_when_current_ip_range_is_banned()
     {
-        $wikiId = Wiki::where('database_name', MediaWikiRepository::getSupportedTargets()[0])
-            ->firstOrFail()->id;
+        $wikiId = Wiki::firstOrFail()->id;
 
         Ban::factory()->create([
             'is_active' => true,
@@ -118,7 +113,7 @@ class AppealCreateBanTest extends TestCase
             'test_do_not_actually_save_anything' => true,
             'appealtext' => 'Example appeal test',
             'appealfor' => 'Not banned user',
-            'wiki' => MediaWikiRepository::getSupportedTargets()[0],
+            'wiki_id' => $wikiId,
             'blocktype' => 1,
         ]);
 
@@ -128,8 +123,7 @@ class AppealCreateBanTest extends TestCase
 
     public function test_cant_create_appeal_for_range_which_is_in_larger_ban()
     {
-        $wikiId = Wiki::where('database_name', MediaWikiRepository::getSupportedTargets()[0])
-            ->firstOrFail()->id;
+        $wikiId = Wiki::firstOrFail()->id;
 
         Ban::factory()
             ->setIP()
@@ -144,7 +138,7 @@ class AppealCreateBanTest extends TestCase
             'test_do_not_actually_save_anything' => true,
             'appealtext' => 'Example appeal test',
             'appealfor' => '10.0.0.0/24',
-            'wiki' => MediaWikiRepository::getSupportedTargets()[0],
+            'wiki_id' => $wikiId,
             'blocktype' => 0,
         ]);
 

--- a/tests/Feature/Jobs/Scheduled/UpdateWikiAppealListJobTest.php
+++ b/tests/Feature/Jobs/Scheduled/UpdateWikiAppealListJobTest.php
@@ -5,10 +5,13 @@ namespace Tests\Feature\Jobs\Scheduled;
 use App\Models\Appeal;
 use App\Services\Facades\MediaWikiRepository;
 use App\Jobs\Scheduled\UpdateWikiAppealListJob;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Tests\TestCase;
 
 class UpdateWikiAppealListJobTest extends TestCase
 {
+    use DatabaseMigrations;
+
     public function getJob()
     {
         return new UpdateWikiAppealListJob(MediaWikiRepository::getSupportedTargets()[0]);
@@ -22,8 +25,7 @@ class UpdateWikiAppealListJobTest extends TestCase
     public function test_renders_standard_appeal_correctly()
     {
         $job = $this->getJob();
-        // add ID manually, since we're not saving it into the database so it doesn't have one itself
-        $appeal = Appeal::factory()->make([ 'id' => 1 ]);
+        $appeal = Appeal::factory()->create();
 
         $text = $job->createContents(collect([$appeal]));
 
@@ -38,8 +40,7 @@ class UpdateWikiAppealListJobTest extends TestCase
     public function test_renders_block_id_appeal_correctly()
     {
         $job = $this->getJob();
-        // add ID manually, since we're not saving it into the database so it doesn't have one itself
-        $appeal = Appeal::factory()->make([ 'id' => 1, 'appealfor' => '#1']);
+        $appeal = Appeal::factory()->create([ 'appealfor' => '#1']);
 
         $text = $job->createContents(collect([$appeal]));
 


### PR DESCRIPTION
Fully moving to the "wikis" table instead of the current config file is
a long process, but this patch brings us one step closer.

It adds a new "wiki_id" column to the "appeals" table, and backfills
said column using the old "wiki" column. Some uses are moved to the new
column, most (relating to permissions) are not yet. The permission table
does not yet operate on wiki ids, which is needed to do that
efficiently.

As a side effect, creating appeals for non-enabled wikis is now also
blocked on the server side. (Previously, the option was just removed on
the client side, but editing the DOM or similar tricks could be used to
submit disabled values).

ref #108
