### PR TITLE
Get rid of '*' as a special permission case

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -76,9 +76,8 @@ class UserController extends Controller
             }
 
             foreach (MediaWikiRepository::getSupportedTargets() as $wiki) {
-                $wikiDbName = $wiki === 'global' ? '*' : $wiki;
                 /** @var Permission $permission */
-                $permission = $user->permissions->where('wiki', $wikiDbName)->first();
+                $permission = $user->permissions->where('wiki', $wiki)->first();
 
                 $updateSet = [];
 
@@ -86,7 +85,7 @@ class UserController extends Controller
                 foreach (Permission::ALL_POSSIBILITIES as $key) {
                     $oldValue = $permission && $permission->$key;
 
-                    if ($currentUser->can('updatePermission', [$user, $wikiDbName, $key])) {
+                    if ($currentUser->can('updatePermission', [$user, $wiki, $key])) {
                         $value = (bool) $request->input('permission.' . $wiki . '.' . $key, false);
 
                         if ($value != $oldValue) {

--- a/app/Http/Controllers/Appeal/AppealQuickSearchController.php
+++ b/app/Http/Controllers/Appeal/AppealQuickSearchController.php
@@ -38,7 +38,7 @@ class AppealQuickSearchController extends Controller
         $wikis = collect(MediaWikiRepository::getSupportedTargets(true));
 
         // For users who aren't developers, stewards or staff, show appeals only for own wikis
-        if (!$user->hasAnySpecifiedLocalOrGlobalPerms(['*'], ['steward', 'staff', 'developer'])) {
+        if (!$user->hasAnySpecifiedLocalOrGlobalPerms(['global'], ['steward', 'staff', 'developer'])) {
             $wikis = $wikis
                 ->filter(function ($wiki) use ($user) {
                     return $user->hasAnySpecifiedLocalOrGlobalPerms($wiki, 'admin');

--- a/app/Http/Controllers/AppealController.php
+++ b/app/Http/Controllers/AppealController.php
@@ -132,7 +132,7 @@ class AppealController extends Controller
         $wikis = collect(MediaWikiRepository::getSupportedTargets());
 
         // For users who aren't developers, stewards or staff, show appeals only for own wikis
-        if (!$isDeveloper && !$user->hasAnySpecifiedLocalOrGlobalPerms(['*'], ['steward', 'staff'])) {
+        if (!$isDeveloper && !$user->hasAnySpecifiedLocalOrGlobalPerms(['global'], ['steward', 'staff'])) {
             $wikis = $wikis
                 ->filter(function ($wiki) use ($user) {
                     $neededPermissions = MediaWikiRepository::getWikiPermissionHandler($wiki)

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Str;
 
 class Permission extends Model
 {
-    protected $appends = ['presentPermissions', 'wikiFormKey'];
+    protected $appends = ['presentPermissions'];
     protected $guarded = ['id'];
     public $timestamps = false;
 
@@ -19,12 +19,6 @@ class Permission extends Model
             ->filter(function ($possiblePerm) {
                 return $this->$possiblePerm;
             });
-    }
-
-    // this is a really stupid hack; but laravel's request()->input('...') doesn't really like form keys with *'s.
-    public function getWikiFormKeyAttribute()
-    {
-        return $this->wiki === '*' ? 'global' : $this->wiki;
     }
 
     public function userObject()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -86,8 +86,8 @@ class User extends Authenticatable
             $wantedPerms = $wantedPerms ? [$wantedPerms] : [];
         }
 
-        if (!in_array('*', $wikis)) {
-            $wikis[] = '*';
+        if (!in_array('global', $wikis)) {
+            $wikis[] = 'global';
         }
 
         return $this->permissions

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -53,7 +53,7 @@ class AuthServiceProvider extends ServiceProvider
                 'updatePermission', // UserPolicy
             ];
 
-            if ($user->hasAnySpecifiedLocalOrGlobalPerms('*', 'developer')
+            if ($user->hasAnySpecifiedLocalOrGlobalPerms('global', 'developer')
                 && !in_array($ability, $doNotOverrideDev)) {
 
                 // allow developers to do everything they'd ever want

--- a/app/Services/MediaWiki/Implementation/RealMediaWikiRepository.php
+++ b/app/Services/MediaWiki/Implementation/RealMediaWikiRepository.php
@@ -40,7 +40,7 @@ class RealMediaWikiRepository implements MediaWikiRepository
         $target = Str::lower($target);
         $prefix = 'wikis.wikis.' . $target . '.';
 
-        if ($target === 'global' || $target === '*') {
+        if ($target === 'global') {
             $prefix = 'wikis.globalwiki.';
         }
 
@@ -77,7 +77,7 @@ class RealMediaWikiRepository implements MediaWikiRepository
 
     public function getWikiAccessChecker(string $wiki): WikiAccessChecker
     {
-        if ($wiki === 'global' || $wiki === '*') {
+        if ($wiki === 'global') {
             return new GlobalAccessChecker($this->getGlobalApi());
         }
 

--- a/database/migrations/2022_03_02_163405_remove_star_permissions.php
+++ b/database/migrations/2022_03_02_163405_remove_star_permissions.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Models\Permission;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Migrations\Migration;
+
+class RemoveStarPermissions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // first, migrate manually granted access (developer and tooladmin) from the '*' wiki to the global one
+        // Don't bother with automatically assigned permissions, those will be fixed automatically
+        $manualPermissions = Permission::query()
+            ->where('wiki', '=', '*')
+            ->where(function (Builder $query) {
+                $query->where('developer', '=', '1')
+                    ->orWhere('tooladmin', '=', '1');
+            });
+
+        foreach ($manualPermissions->get() as $permission) {
+            /** @var Permission $permission */
+            $newPerm = Permission::firstOrNew([
+                'user_id' => $permission->user_id,
+                'wiki' => 'global',
+            ]);
+
+            if ($permission->tooladmin) {
+                $newPerm->tooladmin = true;
+            }
+            if ($permission->developer) {
+                $newPerm->developer = true;
+            }
+
+            $newPerm->save();
+        }
+
+        Permission::query()
+            ->where('wiki', '=', '*')
+            ->delete();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // This migration can not be reversed easily. Hopefully you had backups!
+    }
+}

--- a/database/seeders/UserSeed.php
+++ b/database/seeders/UserSeed.php
@@ -30,7 +30,7 @@ class UserSeed extends Seeder
             Permission::create([
                 'user_id' => $user->id,
                 'developer' => 1,
-                'wiki' => '*',
+                'wiki' => 'global',
             ]);
         }
 

--- a/resources/views/admin/users/view.blade.php
+++ b/resources/views/admin/users/view.blade.php
@@ -69,19 +69,18 @@
                 <tbody>
                 @foreach(\App\Services\Facades\MediaWikiRepository::getSupportedTargets(true) as $wiki)
                     @php
-                        $wikiDbName = $wiki === 'global' ? '*' : $wiki;
                         /** @var \App\Models\User $user */ /** @var \App\Models\Permission $permission */
-                        $permission = $user->permissions->where('wiki', $wikiDbName)->first();
+                        $permission = $user->permissions->where('wiki', $wiki)->first();
                     @endphp
                     <tr>
                         <td>
-                            {{ $wikiDbName }}
+                            {{ $wiki }}
                         </td>
 
                         @foreach(\App\Models\Permission::ALL_POSSIBILITIES as $permNode)
                             @php $oldValue = $permission && $permission->$permNode; @endphp
                             <td>
-                                @can('updatePermission', [$user, $wikiDbName, $permNode])
+                                @can('updatePermission', [$user, $wiki, $permNode])
                                     {{ Form::checkbox('permission[' . $wiki . '][' . $permNode . ']', 1,
                                         old('permission.' . $wiki . '.' . $permNode, $oldValue)) }}
                                 @else

--- a/tests/Feature/Admin/Bans/BanCreateSuppressTest.php
+++ b/tests/Feature/Admin/Bans/BanCreateSuppressTest.php
@@ -31,7 +31,7 @@ class BanCreateSuppressTest extends TestCase
             ->assertDontSee('Ban target visibility');
 
         // get an id of a wiki where the user is a tooladmin, or if globally, for enwiki
-        $wikiId = Wiki::where('database_name', $wikis[0] === '*' ? 'enwiki' : $wikis)
+        $wikiId = Wiki::where('database_name', $wikis[0] === 'global' ? 'enwiki' : $wikis)
             ->firstOrFail()
             ->id;
 
@@ -57,7 +57,7 @@ class BanCreateSuppressTest extends TestCase
             'Normal wiki' => [ ['enwiki'], ],
             'Two normal wikis' => [ ['enwiki', 'ptwiki'], ],
             'Global queue only' => [ ['global'], ],
-            'All wikis' => [ ['*'], ],
+            'All wikis' => [ ['global'], ],
         ];
     }
 

--- a/tests/Feature/Admin/Bans/BanListTest.php
+++ b/tests/Feature/Admin/Bans/BanListTest.php
@@ -110,7 +110,7 @@ class BanListTest extends TestCase
             'wiki_id' => null,
         ]);
 
-        $this->actingAs($this->getTooladminUser([], ['enwiki', '*']))
+        $this->actingAs($this->getTooladminUser([], ['enwiki', 'global']))
             ->get(route('admin.bans.list'))
             ->assertSee('Ban affecting all wikis');
     }

--- a/tests/Feature/Admin/Bans/BanViewSuppressTest.php
+++ b/tests/Feature/Admin/Bans/BanViewSuppressTest.php
@@ -24,7 +24,7 @@ class BanViewSuppressTest extends TestCase
      */
     public function testBanTargetSuppression(string $suppressedOn, array $hasOversightOn, bool $expectedResult)
     {
-        $rights = collect(['enwiki', 'ptwiki', '*'])
+        $rights = collect(['enwiki', 'ptwiki', 'global'])
             ->mapWithKeys(function (string $wiki) use ($hasOversightOn) {
                 return [
                     $wiki => in_array($wiki, $hasOversightOn)
@@ -60,7 +60,7 @@ class BanViewSuppressTest extends TestCase
     {
         return [
             'Local oversighter can view suppressed' => [ 'enwiki', [ 'enwiki' ], true ],
-            'Global oversighter can view suppressed' => [ 'enwiki', [ '*' ], true ],
+            'Global oversighter can view suppressed' => [ 'enwiki', [ 'global' ], true ],
             'Wrong wiki oversighter can not view suppressed' => [ 'enwiki', [ 'ptwiki' ], false ],
             'Regular user can not view suppressed' => [ 'enwiki', [], false ],
         ];

--- a/tests/Traits/TestHasUsers.php
+++ b/tests/Traits/TestHasUsers.php
@@ -68,7 +68,7 @@ trait TestHasUsers
     protected function getDeveloperUser($extraData = []): User
     {
         $permissions = $this->userDefaultPermissions;
-        $permissions['*'] = ['developer'];
+        $permissions['global'] = ['developer'];
         return $this->getUser($permissions, $extraData);
     }
 }


### PR DESCRIPTION
This is causing more hassle than it's worth. So:
 * Remove all references to `*` wiki, replace with `global`.
 * Add a migration script to move manually assigned rights from `*` and `global` and then remove all permission cache entries from `*`.
