### PR TITLE
Correct verf email problem

### DIFF
--- a/app/Http/Controllers/Appeal/PublicAppealController.php
+++ b/app/Http/Controllers/Appeal/PublicAppealController.php
@@ -98,7 +98,7 @@ class PublicAppealController extends Controller
                 'ua'         => $ua . ' ' . $lang,
             ]);
 
-            GetBlockDetailsJob::dispatch($appeal);
+            GetBlockDetailsJob::dispatchNow($appeal);
 
             return $appeal;
         });

--- a/app/Jobs/VerifyBlockJob.php
+++ b/app/Jobs/VerifyBlockJob.php
@@ -38,6 +38,7 @@ class VerifyBlockJob implements ShouldQueue
     {
         // check if the user can be e-mailed according to MediaWiki API
         if (!MediaWikiRepository::getApiForTarget($this->appeal->wiki)->getMediaWikiExtras()->canEmail($this->appeal->getWikiEmailUsername())) {
+            $this->appeal->update(['user_verified'=>-1]);
             return;
         }
 
@@ -62,15 +63,10 @@ class VerifyBlockJob implements ShouldQueue
 
 
             try {
-                if (!MediaWikiRepository::getApiForTarget($appeal->wiki)->getMediaWikiExtras()->canEmail($appeal->getWikiEmailUsername())) {
-                    //user has not set an email on wiki
-                    $this->appeal->update(['user_verified'=>-1]);
-                    return;
-                }
                 $result = MediaWikiRepository::getApiForTarget($this->appeal->wiki)->getMediaWikiExtras()->sendEmail($this->appeal->getWikiEmailUsername(), $title, $message);
 
                 if (!$result) {
-                    throw new RuntimeException('Failed sending an e-mail');
+                    throw new RuntimeException('Failed sending an e-mail: No result from MW API');
                 }
             } catch (Exception $exception) {
                 // wrap exception to add appeal number to log

--- a/app/Services/MediaWiki/Implementation/RealMediaWikiExtras.php
+++ b/app/Services/MediaWiki/Implementation/RealMediaWikiExtras.php
@@ -82,6 +82,10 @@ class RealMediaWikiExtras implements MediaWikiExtras
                 ]
             ));
         } catch (Exception $e) {
+            if (str_contains($e->getMessage(), "Invalid value")) {
+                //UTRS can't recognize this as an IP and MW is rejecting the username
+                return null;
+            }
             Log::error("MediaWiki API Failure: " . $e->getMessage() . " on appealID #". $appealId);
             throw $e;
         }


### PR DESCRIPTION
Attempted correction for https://phabricator.wikimedia.org/T325692
Half this issue is users were not getting marked -1 on no valid email to send to
The other half is likely just an async issue with CSRF not going through properly
and I omni bused another API failure from yesterday's mess into being return null for a block