### PR TITLE
try and fix tests + override appeal spam based on env file

### DIFF
--- a/app/Http/Controllers/Appeal/PublicAppealController.php
+++ b/app/Http/Controllers/Appeal/PublicAppealController.php
@@ -78,7 +78,7 @@ class PublicAppealController extends Controller
             ->openOrRecent()
             ->exists();
 
-        if ($recentAppealExists) {
+        if ($recentAppealExists && env('APP_SPAM_FILTER', true) == true) {
             return view('appeals.spam');
         }
 

--- a/app/Http/Controllers/Appeal/PublicAppealModifyController.php
+++ b/app/Http/Controllers/Appeal/PublicAppealModifyController.php
@@ -101,7 +101,7 @@ class PublicAppealModifyController extends Controller
             ->openOrRecent()
             ->exists();
 
-        if ($recentAppealExists) {
+        if ($recentAppealExists && env('APP_SPAM_FILTER', true) == true) {
             return view('appeals.spam');
         }
 

--- a/tests/Browser/Appeals/AppealCommentsTest.php
+++ b/tests/Browser/Appeals/AppealCommentsTest.php
@@ -26,6 +26,7 @@ class AppealCommentsTest extends DuskTestCase
                 ->assertSee(Appeal::STATUS_AWAITING_REPLY)
                 ->type('comment', 'This is an example comment')
                 ->press('Submit')
+                ->press('View appeal details')
                 ->assertSee('This is an example comment')
                 ->assertSee(Appeal::STATUS_OPEN)
                 ->assertDontSee(Appeal::STATUS_AWAITING_REPLY);

--- a/tests/Browser/Appeals/AppealCommentsTest.php
+++ b/tests/Browser/Appeals/AppealCommentsTest.php
@@ -21,7 +21,8 @@ class AppealCommentsTest extends DuskTestCase
         ]);
 
         $this->browse(function (Browser $browser) use ($appeal) {
-            $browser->visit('/public/appeal/view?hash=' . $appeal->appealsecretkey)
+            $browser->visit('/')->type('appealkey',$appeal->appealsecretkey)
+                ->press('View my appeal')
                 ->assertSee(Appeal::STATUS_AWAITING_REPLY)
                 ->type('comment', 'This is an example comment')
                 ->press('Submit')

--- a/tests/Browser/Appeals/AppealPublicActionsTest.php
+++ b/tests/Browser/Appeals/AppealPublicActionsTest.php
@@ -43,6 +43,7 @@ class AppealPublicActionsTest extends DuskTestCase
                 ->assertInputValue('appealfor', $appeal->appealfor)
                 ->type('appealfor', 'Blocked user')
                 ->press('Submit')
+                ->press('View appeal details')
                 ->assertSee('Appeal for "Blocked user"');
         });
     }

--- a/tests/Browser/Appeals/AppealPublicActionsTest.php
+++ b/tests/Browser/Appeals/AppealPublicActionsTest.php
@@ -38,7 +38,7 @@ class AppealPublicActionsTest extends DuskTestCase
                 ->assertSee(Appeal::STATUS_NOTFOUND)
                 ->assertDontSee('Add a comment to this appeal')
                 ->assertSee('We were not able to locate your block. Please')
-                ->clickLink('Fix block information')
+                ->click('Fix block information')
                 ->assertSee('You are now modifying your appeal to be resubmitted. Please ensure the information is correct.')
                 ->assertInputValue('appealfor', $appeal->appealfor)
                 ->type('appealfor', 'Blocked user')

--- a/tests/Browser/Appeals/AppealPublicActionsTest.php
+++ b/tests/Browser/Appeals/AppealPublicActionsTest.php
@@ -38,7 +38,7 @@ class AppealPublicActionsTest extends DuskTestCase
                 ->assertSee(Appeal::STATUS_NOTFOUND)
                 ->assertDontSee('Add a comment to this appeal')
                 ->assertSee('We were not able to locate your block. Please')
-                ->click('Fix block information')
+                ->press('Fix block information')
                 ->assertSee('You are now modifying your appeal to be resubmitted. Please ensure the information is correct.')
                 ->assertInputValue('appealfor', $appeal->appealfor)
                 ->type('appealfor', 'Blocked user')

--- a/tests/Browser/Appeals/AppealPublicActionsTest.php
+++ b/tests/Browser/Appeals/AppealPublicActionsTest.php
@@ -17,7 +17,8 @@ class AppealPublicActionsTest extends DuskTestCase
             $appeal = Appeal::factory()->create();
             $appealTextStart = explode("\n", $appeal->appealtext)[0];
 
-            $browser->visit('/public/appeal/view?hash=' . $appeal->appealsecretkey)
+            $browser->visit('/')->type('appealkey',$appeal->appealsecretkey)
+                    ->press('View my appeal')
                     ->assertSee('Appeal for "' . $appeal->appealfor . '"')
                     ->assertSee($appeal->status)
                     ->assertSee($appealTextStart)
@@ -31,7 +32,8 @@ class AppealPublicActionsTest extends DuskTestCase
         $this->browse(function (Browser $browser) {
             $appeal = Appeal::factory()->create([ 'status' => Appeal::STATUS_NOTFOUND, ]);
 
-            $browser->visit('/public/appeal/view?hash=' . $appeal->appealsecretkey)
+            $browser->visit('/')->type('appealkey',$appeal->appealsecretkey)
+                ->press('View my appeal')
                 ->assertSee('Appeal for "' . $appeal->appealfor . '"')
                 ->assertSee(Appeal::STATUS_NOTFOUND)
                 ->assertDontSee('Add a comment to this appeal')


### PR DESCRIPTION
Resolve #209 
Also quick fixes to tests that couldn't be ran with today's security deployment