### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/laravel-tests.yml
+++ b/.github/workflows/laravel-tests.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
   pull_request: {}
+permissions:
+  contents: read
 jobs:
   laravel-tests:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Potential fix for [https://github.com/UTRS2/utrs/security/code-scanning/12](https://github.com/UTRS2/utrs/security/code-scanning/12)

Add an explicit `permissions` block to `.github/workflows/laravel-tests.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves current behavior (checkout and normal CI tasks) while preventing unnecessary write access from the default token settings.

Change location: directly after the `on:` trigger section and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
